### PR TITLE
fix: properly track token usage and per-phase LLM call counts

### DIFF
--- a/evaluation/locomo/add.py
+++ b/evaluation/locomo/add.py
@@ -180,6 +180,9 @@ async def process_dataset(
         ]
         results = await tqdm.gather(*tasks, desc="Conversations")
 
+        # Collect orchestrator stats before context manager exits
+        orch_stats = memory._system._orchestrator.stats if memory._system else None
+
     # Print summary
     successful = sum(1 for r in results if r.get("success"))
     failed = len(results) - successful
@@ -191,6 +194,22 @@ async def process_dataset(
     print(f"Successful: {successful}/{len(dataset)}")
     print(f"Failed: {failed}/{len(dataset)}")
     print(f"Total episodes created: {total_episodes}")
+
+    if orch_stats:
+        print(f"\n{'─' * 60}")
+        print("LLM Usage Details")
+        print(f"{'─' * 60}")
+        print(f"Total LLM calls:        {orch_stats.total_requests}")
+        print(f"Total tokens:           {orch_stats.total_tokens}")
+        print(f"  Prompt tokens:        {orch_stats.total_prompt_tokens}")
+        print(f"  Completion tokens:    {orch_stats.total_completion_tokens}")
+        print(f"Total errors:           {orch_stats.total_errors}")
+        print(f"Avg latency:            {orch_stats.avg_latency_ms:.0f}ms")
+        if orch_stats.requests_by_phase:
+            print(f"\nLLM calls by phase:")
+            for phase, count in sorted(orch_stats.requests_by_phase.items()):
+                tokens = orch_stats.tokens_by_phase.get(phase, 0)
+                print(f"  {phase:25s}  calls={count:4d}  tokens={tokens:,}")
 
     if failed > 0:
         print("\nFailure Details:")

--- a/nemori/core/memory_system.py
+++ b/nemori/core/memory_system.py
@@ -240,7 +240,13 @@ class MemorySystem:
             "pending_messages": buffer_count,
             "orchestrator_stats": {
                 "total_requests": self._orchestrator.stats.total_requests,
+                "total_tokens": self._orchestrator.stats.total_tokens,
+                "prompt_tokens": self._orchestrator.stats.total_prompt_tokens,
+                "completion_tokens": self._orchestrator.stats.total_completion_tokens,
                 "total_errors": self._orchestrator.stats.total_errors,
+                "avg_latency_ms": round(self._orchestrator.stats.avg_latency_ms, 1),
+                "requests_by_phase": self._orchestrator.stats.requests_by_phase,
+                "tokens_by_phase": self._orchestrator.stats.tokens_by_phase,
             },
         }
 

--- a/nemori/domain/interfaces.py
+++ b/nemori/domain/interfaces.py
@@ -69,3 +69,9 @@ class LLMProvider(Protocol):
     """LLM call protocol."""
 
     async def complete(self, messages: list[dict], **kwargs: object) -> str: ...
+
+    async def complete_with_usage(
+        self, messages: list[dict], **kwargs: object
+    ) -> tuple[str, dict[str, int]]:
+        """Return (content, {"prompt_tokens": ..., "completion_tokens": ...})."""
+        ...

--- a/nemori/llm/client.py
+++ b/nemori/llm/client.py
@@ -14,10 +14,19 @@ logger = logging.getLogger("nemori")
 class AsyncLLMClient:
     """Async LLM client wrapping the OpenAI API."""
 
+    supports_usage_tracking: bool = True
+
     def __init__(self, api_key: str, base_url: str | None = None) -> None:
         self._client = AsyncOpenAI(api_key=api_key, base_url=base_url)
 
     async def complete(self, messages: list[dict], **kwargs: Any) -> str:
+        content, _ = await self.complete_with_usage(messages, **kwargs)
+        return content
+
+    async def complete_with_usage(
+        self, messages: list[dict], **kwargs: Any
+    ) -> tuple[str, dict[str, int]]:
+        """Return (content, {"prompt_tokens": ..., "completion_tokens": ...})."""
         model = kwargs.pop("model", "gpt-4o-mini")
         temperature = kwargs.pop("temperature", 0.7)
         max_tokens = kwargs.pop("max_tokens", 2000)
@@ -30,8 +39,12 @@ class AsyncLLMClient:
                 max_tokens=max_tokens,
                 **kwargs,
             )
-            content = response.choices[0].message.content
-            return content or ""
+            content = response.choices[0].message.content or ""
+            usage = {
+                "prompt_tokens": getattr(response.usage, "prompt_tokens", 0) or 0,
+                "completion_tokens": getattr(response.usage, "completion_tokens", 0) or 0,
+            }
+            return content, usage
         except Exception as e:
             error_str = str(e)
             if "401" in error_str or "403" in error_str:

--- a/nemori/llm/orchestrator.py
+++ b/nemori/llm/orchestrator.py
@@ -58,8 +58,12 @@ class LLMResponse:
 class OrchestratorStats:
     total_requests: int = 0
     total_tokens: int = 0
+    total_prompt_tokens: int = 0
+    total_completion_tokens: int = 0
     total_errors: int = 0
     avg_latency_ms: float = 0.0
+    requests_by_phase: dict[str, int] = field(default_factory=dict)
+    tokens_by_phase: dict[str, int] = field(default_factory=dict)
 
 
 class LLMOrchestrator:
@@ -80,8 +84,14 @@ class LLMOrchestrator:
         self._log = logger or logging.getLogger("nemori")
         self._total_requests = 0
         self._total_tokens = 0
+        self._total_prompt_tokens = 0
+        self._total_completion_tokens = 0
         self._total_errors = 0
         self._total_latency_ms = 0.0
+        self._requests_by_phase: dict[str, int] = {}
+        self._tokens_by_phase: dict[str, int] = {}
+        # Enable usage tracking if provider explicitly declares support
+        self._track_usage = getattr(provider, "supports_usage_tracking", False)
 
     async def execute(self, request: LLMRequest) -> LLMResponse:
         if self._token_budget and self._total_tokens >= self._token_budget:
@@ -102,25 +112,52 @@ class LLMOrchestrator:
                     extra_kwargs: dict[str, Any] = {}
                     if request.response_format is not None:
                         extra_kwargs["response_format"] = request.response_format
-                    content = await asyncio.wait_for(
-                        self._provider.complete(
-                            list(request.messages),
-                            model=model,
-                            temperature=request.temperature,
-                            max_tokens=request.max_tokens,
-                            **extra_kwargs,
-                        ),
-                        timeout=request.timeout,
+
+                    call_kwargs = dict(
+                        model=model,
+                        temperature=request.temperature,
+                        max_tokens=request.max_tokens,
+                        **extra_kwargs,
                     )
+                    # Use complete_with_usage if available to capture token counts
+                    usage = TokenUsage()
+                    if self._track_usage:
+                        result = await asyncio.wait_for(
+                            self._provider.complete_with_usage(
+                                list(request.messages), **call_kwargs,
+                            ),
+                            timeout=request.timeout,
+                        )
+                        content, raw_usage = result
+                        usage = TokenUsage(
+                            prompt_tokens=raw_usage.get("prompt_tokens", 0),
+                            completion_tokens=raw_usage.get("completion_tokens", 0),
+                        )
+                    else:
+                        content = await asyncio.wait_for(
+                            self._provider.complete(
+                                list(request.messages), **call_kwargs,
+                            ),
+                            timeout=request.timeout,
+                        )
+                        usage = TokenUsage()
                     latency = (time.monotonic() - start) * 1000
 
                 self._total_requests += 1
+                self._total_tokens += usage.total
+                self._total_prompt_tokens += usage.prompt_tokens
+                self._total_completion_tokens += usage.completion_tokens
                 self._total_latency_ms += latency
+
+                # Track per-phase stats from metadata
+                phase = request.metadata.get("generator", "unknown")
+                self._requests_by_phase[phase] = self._requests_by_phase.get(phase, 0) + 1
+                self._tokens_by_phase[phase] = self._tokens_by_phase.get(phase, 0) + usage.total
 
                 response = LLMResponse(
                     content=content,
                     model=model,
-                    usage=TokenUsage(),
+                    usage=usage,
                     latency_ms=latency,
                     request_id=request_id,
                 )
@@ -159,6 +196,10 @@ class LLMOrchestrator:
         return OrchestratorStats(
             total_requests=self._total_requests,
             total_tokens=self._total_tokens,
+            total_prompt_tokens=self._total_prompt_tokens,
+            total_completion_tokens=self._total_completion_tokens,
             total_errors=self._total_errors,
             avg_latency_ms=avg,
+            requests_by_phase=dict(self._requests_by_phase),
+            tokens_by_phase=dict(self._tokens_by_phase),
         )

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -10,6 +10,7 @@ from nemori.domain.exceptions import LLMError, TokenBudgetExceeded
 def mock_provider():
     provider = AsyncMock()
     provider.complete = AsyncMock(return_value="response text")
+    provider.supports_usage_tracking = False
     return provider
 
 
@@ -42,6 +43,7 @@ async def test_execute_retries_on_error(mock_provider):
         return "success"
 
     mock_provider.complete = flaky_complete
+    mock_provider.supports_usage_tracking = False
     orch = LLMOrchestrator(provider=mock_provider, default_model="gpt-4o-mini")
     request = LLMRequest(messages=({"role": "user", "content": "hi"},), retries=3)
     response = await orch.execute(request)
@@ -64,6 +66,7 @@ async def test_concurrency_limit():
 
     provider = AsyncMock()
     provider.complete = slow_complete
+    provider.supports_usage_tracking = False
     orch = LLMOrchestrator(provider=provider, default_model="m", max_concurrent=2)
     requests = [LLMRequest(messages=({"role": "user", "content": f"{i}"},)) for i in range(5)]
     await orch.execute_batch(requests)
@@ -72,6 +75,7 @@ async def test_concurrency_limit():
 
 @pytest.mark.asyncio
 async def test_token_budget_exceeded(mock_provider):
+    mock_provider.supports_usage_tracking = False
     orch = LLMOrchestrator(provider=mock_provider, default_model="m", token_budget=100)
     orch._total_tokens = 100
     request = LLMRequest(messages=({"role": "user", "content": "hi"},))
@@ -85,3 +89,66 @@ async def test_stats_tracking(orchestrator, mock_provider):
     await orchestrator.execute(request)
     stats = orchestrator.stats
     assert stats.total_requests >= 1
+
+
+@pytest.mark.asyncio
+async def test_usage_tracking_with_provider():
+    """Test that token usage is properly tracked when provider supports it."""
+    provider = AsyncMock()
+    provider.supports_usage_tracking = True
+    provider.complete_with_usage = AsyncMock(
+        return_value=("response text", {"prompt_tokens": 50, "completion_tokens": 30})
+    )
+    orch = LLMOrchestrator(provider=provider, default_model="gpt-4o-mini")
+
+    from types import MappingProxyType
+    request = LLMRequest(
+        messages=({"role": "user", "content": "hi"},),
+        metadata=MappingProxyType({"generator": "episode"}),
+    )
+    response = await orch.execute(request)
+    assert response.usage.prompt_tokens == 50
+    assert response.usage.completion_tokens == 30
+    assert response.usage.total == 80
+
+    stats = orch.stats
+    assert stats.total_tokens == 80
+    assert stats.total_prompt_tokens == 50
+    assert stats.total_completion_tokens == 30
+    assert stats.requests_by_phase == {"episode": 1}
+    assert stats.tokens_by_phase == {"episode": 80}
+
+
+@pytest.mark.asyncio
+async def test_per_phase_tracking():
+    """Test that per-phase stats correctly distinguish different generator types."""
+    provider = AsyncMock()
+    provider.supports_usage_tracking = True
+    provider.complete_with_usage = AsyncMock(
+        return_value=("response", {"prompt_tokens": 100, "completion_tokens": 50})
+    )
+    orch = LLMOrchestrator(provider=provider, default_model="gpt-4o-mini")
+
+    from types import MappingProxyType
+    # Simulate episode generation (1 call)
+    await orch.execute(LLMRequest(
+        messages=({"role": "user", "content": "hi"},),
+        metadata=MappingProxyType({"generator": "episode"}),
+    ))
+    # Simulate semantic prediction (1 call)
+    await orch.execute(LLMRequest(
+        messages=({"role": "user", "content": "predict"},),
+        metadata=MappingProxyType({"generator": "semantic_predict"}),
+    ))
+    # Simulate semantic extraction (1 call)
+    await orch.execute(LLMRequest(
+        messages=({"role": "user", "content": "extract"},),
+        metadata=MappingProxyType({"generator": "semantic_extract"}),
+    ))
+
+    stats = orch.stats
+    assert stats.total_requests == 3
+    assert stats.total_tokens == 450  # 150 * 3
+    assert stats.requests_by_phase["episode"] == 1
+    assert stats.requests_by_phase["semantic_predict"] == 1
+    assert stats.requests_by_phase["semantic_extract"] == 1


### PR DESCRIPTION
The token calculation was broken because AsyncLLMClient.complete() discarded the API response's usage field and only returned content. The orchestrator created LLMResponse with TokenUsage(0,0), so _total_tokens was never updated.

Changes:
- Add complete_with_usage() to AsyncLLMClient that returns (content, usage_dict)
- Update LLMOrchestrator to use complete_with_usage when provider supports it
- Add per-phase (episode, semantic_predict, semantic_extract, etc.) tracking via requests_by_phase and tokens_by_phase counters
- Expose detailed stats in MemorySystem.stats() including prompt/completion token breakdown and per-phase counts
- Update add.py to print detailed LLM usage report
- Add tests for usage tracking and per-phase stats

Fixes #11

https://claude.ai/code/session_01UT9WWMWb46q1jgzq6tQH1P