### PR TITLE
Fix Qdrant Docker healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,10 @@ services:
     volumes:
       - nemori_qdrant_data:/qdrant/storage
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:6333/healthz"]
+      test:
+        - CMD-SHELL
+        - >-
+          bash -ec 'exec 3<>/dev/tcp/127.0.0.1/6333; printf "GET /readyz HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" >&3; read -r status <&3; [[ $$status == *" 200 "* ]]'
       interval: 5s
       timeout: 3s
       retries: 5


### PR DESCRIPTION
## Summary
- replace the Qdrant Docker Compose healthcheck that depends on `wget`
- check Qdrant's `/readyz` endpoint using shell built-ins available in the container

## Why
The current healthcheck runs `wget --spider` inside the `qdrant/qdrant:latest` container, but that image does not include `wget`. As a result, Docker can mark Qdrant as unhealthy even when the service is responding.

This keeps the healthcheck dependency-light while checking Qdrant's readiness endpoint instead of only testing whether the port is open.

## Verification
- `docker compose config --quiet`
- `docker compose ps` shows `nemori-qdrant-1` healthy
- `curl -sS http://localhost:6333/readyz` returns `all shards are ready`
- confirmed the previous `wget` healthcheck fails with `exec: "wget": executable file not found in $PATH`