### PR TITLE
Add GPT-5 chat compatibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # === LLM Configuration ===
 LLM_API_KEY=your_api_key_here
 LLM_BASE_URL=https://openrouter.ai/api/v1    # OpenRouter, or leave empty for direct OpenAI
+LLM_MODEL=openai/gpt-5-mini                # For direct OpenAI, use gpt-5-mini
+# LLM_MODEL=openai/gpt-5-nano               # Lowest-cost GPT-5 option for simpler tasks
+# LLM_MODEL=openai/gpt-4o                   # GPT-4o option for legacy-compatible behavior
 
 # === Embedding Configuration ===
 EMBEDDING_API_KEY=your_api_key_here           # Can be same as LLM_API_KEY for OpenRouter

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # === LLM Configuration ===
 LLM_API_KEY=your_api_key_here
 LLM_BASE_URL=https://openrouter.ai/api/v1    # OpenRouter, or leave empty for direct OpenAI
-LLM_MODEL=openai/gpt-5-mini                # For direct OpenAI, use gpt-5-mini
+LLM_MODEL=openai/gpt-5-mini                # GPT-5 option; use gpt-5-mini for direct OpenAI
 # LLM_MODEL=openai/gpt-5-nano               # Lowest-cost GPT-5 option for simpler tasks
 # LLM_MODEL=openai/gpt-4o                   # GPT-4o option for legacy-compatible behavior
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Nemori only reads these variables; it never writes secrets to disk. 🔒
 
 Model choices:
 
-- `gpt-5-mini` (`openai/gpt-5-mini` on OpenRouter): recommended GPT-5 default
+- `gpt-5-mini` (`openai/gpt-5-mini` on OpenRouter): recommended GPT-5 option
   for a balance of quality, cost, and reliability in memory generation.
 - `gpt-5-nano` (`openai/gpt-5-nano` on OpenRouter): lowest-cost GPT-5
   option, best for simpler summarization and classification tasks.
@@ -109,7 +109,6 @@ async def main():
     # DSN, API keys, base URLs, and model defaults are resolved from environment variables.
     # Override model names here only when you need per-instance settings.
     config = MemoryConfig(
-        llm_model="openai/gpt-4.1-mini",
         embedding_model="google/gemini-embedding-001",
     )
     async with NemoriMemory(config) as memory:

--- a/README.md
+++ b/README.md
@@ -73,15 +73,31 @@ Create a `.env` file in the repo root:
 # OpenRouter (recommended — single key for both LLM and embeddings)
 LLM_API_KEY=sk-or-...
 LLM_BASE_URL=https://openrouter.ai/api/v1
+LLM_MODEL=openai/gpt-5-mini
 EMBEDDING_API_KEY=sk-or-...
 EMBEDDING_BASE_URL=https://openrouter.ai/api/v1
 
 # Or use direct OpenAI
 # LLM_API_KEY=sk-...
+# LLM_MODEL=gpt-5-mini
 # EMBEDDING_API_KEY=sk-...
 ```
 
 Nemori only reads these variables; it never writes secrets to disk. 🔒
+
+Model choices:
+
+- `gpt-5-mini` (`openai/gpt-5-mini` on OpenRouter): recommended GPT-5 default
+  for a balance of quality, cost, and reliability in memory generation.
+- `gpt-5-nano` (`openai/gpt-5-nano` on OpenRouter): lowest-cost GPT-5
+  option, best for simpler summarization and classification tasks.
+- `gpt-4o` (`openai/gpt-4o` on OpenRouter): GPT-4o option for users who
+  prefer legacy-compatible behavior.
+
+See OpenAI model docs for current capabilities and pricing:
+[`gpt-5-mini`](https://platform.openai.com/docs/models/gpt-5-mini),
+[`gpt-5-nano`](https://platform.openai.com/docs/models/gpt-5-nano), and
+[`gpt-4o`](https://platform.openai.com/docs/models/gpt-4o).
 
 ### 2.4 💡 Minimal usage
 
@@ -90,8 +106,8 @@ import asyncio
 from nemori import NemoriMemory, MemoryConfig
 
 async def main():
-    # DSN, API keys, and base URLs are resolved from environment variables.
-    # Only model names need to be specified explicitly.
+    # DSN, API keys, base URLs, and model defaults are resolved from environment variables.
+    # Override model names here only when you need per-instance settings.
     config = MemoryConfig(
         llm_model="openai/gpt-4.1-mini",
         embedding_model="google/gemini-embedding-001",

--- a/nemori/config.py
+++ b/nemori/config.py
@@ -35,6 +35,10 @@ def _resolve_base_url(env_key: str) -> str | None:
     return os.getenv(env_key) or None
 
 
+def _resolve_llm_model() -> str:
+    return os.getenv("LLM_MODEL") or "gpt-4o-mini"
+
+
 @dataclass
 class MemoryConfig:
     """Configuration for the Nemori memory system."""
@@ -48,7 +52,7 @@ class MemoryConfig:
     agent_id: str = "default"
 
     # LLM
-    llm_model: str = "gpt-4o-mini"
+    llm_model: str = field(default_factory=_resolve_llm_model)
     llm_api_key: str = field(default_factory=_resolve_llm_key)
     llm_base_url: str | None = field(default_factory=lambda: _resolve_base_url("LLM_BASE_URL"))
     llm_max_concurrent: int = 10

--- a/nemori/llm/client.py
+++ b/nemori/llm/client.py
@@ -12,7 +12,6 @@ logger = logging.getLogger("nemori")
 
 DEFAULT_OPENAI_CHAT_MODEL = "gpt-4o-mini"
 GPT5_MODEL_PREFIXES = ("gpt-5",)
-DEFAULT_GPT5_REASONING_EFFORT = "minimal"
 
 
 def _base_model_name(model: str) -> str:
@@ -41,9 +40,7 @@ def _chat_completion_kwargs(
         params["max_completion_tokens"] = extra.pop(
             "max_completion_tokens", max_tokens
         )
-        reasoning_effort = extra.pop(
-            "reasoning_effort", DEFAULT_GPT5_REASONING_EFFORT
-        )
+        reasoning_effort = extra.pop("reasoning_effort", None)
         if reasoning_effort is not None:
             params["reasoning_effort"] = reasoning_effort
     else:

--- a/nemori/llm/client.py
+++ b/nemori/llm/client.py
@@ -10,6 +10,49 @@ from nemori.domain.exceptions import LLMError, LLMAuthError, LLMRateLimitError
 
 logger = logging.getLogger("nemori")
 
+DEFAULT_OPENAI_CHAT_MODEL = "gpt-4o-mini"
+GPT5_MODEL_PREFIXES = ("gpt-5",)
+DEFAULT_GPT5_REASONING_EFFORT = "minimal"
+
+
+def _base_model_name(model: str) -> str:
+    """Return provider-free model name, e.g. openai/gpt-5-mini -> gpt-5-mini."""
+    return model.rsplit("/", maxsplit=1)[-1].lower()
+
+
+def is_gpt5_model(model: str) -> bool:
+    return _base_model_name(model).startswith(GPT5_MODEL_PREFIXES)
+
+
+def _chat_completion_kwargs(
+    *,
+    model: str,
+    messages: list[dict],
+    temperature: float,
+    max_tokens: int,
+    extra: dict[str, Any],
+) -> dict[str, Any]:
+    params: dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+    }
+
+    if is_gpt5_model(model):
+        params["max_completion_tokens"] = extra.pop(
+            "max_completion_tokens", max_tokens
+        )
+        reasoning_effort = extra.pop(
+            "reasoning_effort", DEFAULT_GPT5_REASONING_EFFORT
+        )
+        if reasoning_effort is not None:
+            params["reasoning_effort"] = reasoning_effort
+    else:
+        params["temperature"] = temperature
+        params["max_tokens"] = max_tokens
+
+    params.update(extra)
+    return params
+
 
 class AsyncLLMClient:
     """Async LLM client wrapping the OpenAI API."""
@@ -27,18 +70,19 @@ class AsyncLLMClient:
         self, messages: list[dict], **kwargs: Any
     ) -> tuple[str, dict[str, int]]:
         """Return (content, {"prompt_tokens": ..., "completion_tokens": ...})."""
-        model = kwargs.pop("model", "gpt-4o-mini")
+        model = kwargs.pop("model", DEFAULT_OPENAI_CHAT_MODEL)
         temperature = kwargs.pop("temperature", 0.7)
         max_tokens = kwargs.pop("max_tokens", 2000)
 
         try:
-            response = await self._client.chat.completions.create(
+            request_kwargs = _chat_completion_kwargs(
                 model=model,
                 messages=messages,
                 temperature=temperature,
                 max_tokens=max_tokens,
-                **kwargs,
+                extra=kwargs,
             )
+            response = await self._client.chat.completions.create(**request_kwargs)
             content = response.choices[0].message.content or ""
             usage = {
                 "prompt_tokens": getattr(response.usage, "prompt_tokens", 0) or 0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 
 dependencies = [
     "asyncpg>=0.29.0",
-    "openai>=1.0.0",
+    "openai>=2.0.0",
     "tiktoken>=0.5.0",
     "pydantic>=2.0.0",
     "python-dotenv>=1.0.0",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,8 @@ from nemori.config import MemoryConfig
 from nemori.domain.exceptions import ConfigError
 
 
-def test_default_config():
+def test_default_config(monkeypatch):
+    monkeypatch.delenv("LLM_MODEL", raising=False)
     cfg = MemoryConfig()
     assert "nemori" in cfg.dsn  # DSN resolved from env or default
     assert cfg.db_pool_min == 5
@@ -15,6 +16,12 @@ def test_default_config():
     assert cfg.embedding_dimension == 1536
     assert cfg.buffer_size_min == 2
     assert cfg.search_top_k_episodes == 10
+
+
+def test_config_reads_env_for_llm_model(monkeypatch):
+    monkeypatch.setenv("LLM_MODEL", "gpt-5-mini")
+    cfg = MemoryConfig()
+    assert cfg.llm_model == "gpt-5-mini"
 
 
 def test_config_reads_env_for_llm_api_key(monkeypatch):

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -54,7 +54,7 @@ async def test_complete_adapts_gpt5_params():
         call_kwargs = mock_client.chat.completions.create.call_args[1]
         assert call_kwargs["model"] == "gpt-5-nano"
         assert call_kwargs["max_completion_tokens"] == 100
-        assert call_kwargs["reasoning_effort"] == "minimal"
+        assert "reasoning_effort" not in call_kwargs
         assert "max_tokens" not in call_kwargs
         assert "temperature" not in call_kwargs
 

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -36,3 +36,47 @@ async def test_complete_passes_params():
         assert call_kwargs["model"] == "gpt-4o"
         assert call_kwargs["temperature"] == 0.5
         assert call_kwargs["max_tokens"] == 100
+
+
+@pytest.mark.asyncio
+async def test_complete_adapts_gpt5_params():
+    client = AsyncLLMClient(api_key="test-key", base_url=None)
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = "ok"
+
+    with patch.object(client, "_client") as mock_client:
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+        await client.complete(
+            [{"role": "user", "content": "hi"}],
+            model="gpt-5-nano", temperature=0.5, max_tokens=100,
+        )
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["model"] == "gpt-5-nano"
+        assert call_kwargs["max_completion_tokens"] == 100
+        assert call_kwargs["reasoning_effort"] == "minimal"
+        assert "max_tokens" not in call_kwargs
+        assert "temperature" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_complete_adapts_provider_prefixed_gpt5_params():
+    client = AsyncLLMClient(api_key="test-key", base_url="https://openrouter.ai/api/v1")
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = "ok"
+
+    with patch.object(client, "_client") as mock_client:
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+        await client.complete(
+            [{"role": "user", "content": "hi"}],
+            model="openai/gpt-5-mini",
+            max_tokens=100,
+            reasoning_effort="low",
+        )
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["model"] == "openai/gpt-5-mini"
+        assert call_kwargs["max_completion_tokens"] == 100
+        assert call_kwargs["reasoning_effort"] == "low"
+        assert "max_tokens" not in call_kwargs
+        assert "temperature" not in call_kwargs

--- a/uv.lock
+++ b/uv.lock
@@ -2727,7 +2727,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "nltk", specifier = ">=3.8.0" },
     { name = "numpy", specifier = ">=1.24.0" },
-    { name = "openai", specifier = ">=1.0.0" },
+    { name = "openai", specifier = ">=2.0.0" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },


### PR DESCRIPTION
## Summary
- Add model-aware Chat Completions request handling for GPT-5 family models.
- Preserve existing GPT-4/GPT-4o behavior by continuing to send temperature and max_tokens for non-GPT-5 models.
- Add LLM_MODEL environment configuration and document GPT-5 mini, GPT-5 nano, and GPT-4o choices with OpenAI docs links.
- Add focused tests for GPT-4 parameter preservation, GPT-5 parameter adaptation, provider-prefixed GPT-5 model IDs, and LLM_MODEL config.
- Raise the OpenAI SDK lower bound to 2.0.0 so package metadata matches the GPT-5 request parameters used by the client.

## Design decision
This PR intentionally keeps Nemori on the existing Chat Completions path and makes that path compatible with GPT-5-style models. A broader Responses API migration would touch more provider plumbing and should be reviewed separately if maintainers want that modernization later.

For GPT-5-family model IDs, the client now sends max_completion_tokens instead of max_tokens and omits custom temperature. It does not force a reasoning_effort default; callers may pass reasoning_effort explicitly when they want to override provider/model defaults. GPT-4/GPT-4o requests keep the previous parameter shape.

The docs describe gpt-5-mini as a recommended GPT-5 option, not a forced project default. Users can still choose GPT-4o/GPT-4o-mini behavior by setting LLM_MODEL accordingly.

## Verification
- .venv/bin/python -m compileall nemori tests/test_llm_client.py tests/test_config.py
- Direct helper check for GPT-4 vs provider-prefixed GPT-5 request kwargs, including explicit reasoning_effort passthrough
- Direct config check for LLM_MODEL env override
- Local OpenAI SDK signature check on openai==2.6.1 confirms max_completion_tokens and reasoning_effort are supported
- git diff --check

Full pytest via uv was not run locally because dependency resolution stops before pytest: torch==2.9.0 has no macOS x86_64 wheel for this environment.