### PR TITLE
Fix semantic memory deduplication and unknown type fallback

### DIFF
--- a/nemori/config.py
+++ b/nemori/config.py
@@ -80,6 +80,9 @@ class MemoryConfig:
     enable_semantic_memory: bool = True
     enable_prediction_correction: bool = True
     semantic_similarity_threshold: float = 0.85
+    # When a newly extracted fact is within semantic_similarity_threshold of an
+    # existing one, supersede the existing memory instead of appending a copy.
+    enable_semantic_dedup: bool = True
 
     # Episode Merging
     enable_episode_merging: bool = True

--- a/nemori/core/memory_system.py
+++ b/nemori/core/memory_system.py
@@ -179,6 +179,7 @@ class MemorySystem:
                 user_id, self._agent_id, episode, existing_sem
             )
             if memories:
+                memories = await self._dedupe_semantic(user_id, memories)
                 await self._semantic_store.save_batch(memories)
                 # Upsert semantic vectors to Qdrant
                 if self._qdrant:
@@ -193,6 +194,43 @@ class MemorySystem:
                 )
         except Exception as e:
             logger.error("Semantic generation failed for user %s: %s", user_id, e)
+
+    async def _dedupe_semantic(
+        self, user_id: str, memories: list[SemanticMemory]
+    ) -> list[SemanticMemory]:
+        """Collapse near-duplicate facts onto the existing memory they supersede.
+
+        Without this, every extraction appends a fresh row, so a changed fact
+        ("works at Acme" -> "works at Globex") leaves both copies live with no
+        link between them. A new fact whose embedding is within
+        ``semantic_similarity_threshold`` of an existing one reuses that id, so
+        the store's ON CONFLICT DO UPDATE supersedes it (latest content wins).
+        """
+        if not (self._qdrant and self._config.enable_semantic_dedup):
+            return memories
+        threshold = self._config.semantic_similarity_threshold
+        used_ids: set[str] = set()
+        for mem in memories:
+            if not mem.embedding:
+                continue
+            hits = self._qdrant.search_semantic(
+                user_id, self._agent_id, mem.embedding, top_k=1,
+            )
+            existing_id = self._resolve_dedupe_id(hits, threshold, used_ids)
+            if existing_id:
+                mem.id = existing_id
+                mem.updated_at = mem.created_at
+                used_ids.add(existing_id)
+        return memories
+
+    @staticmethod
+    def _resolve_dedupe_id(
+        hits: list[dict[str, Any]], threshold: float, used_ids: set[str]
+    ) -> str | None:
+        """Return an existing memory id to supersede, or None to keep as new."""
+        if hits and hits[0]["score"] >= threshold and hits[0]["id"] not in used_ids:
+            return hits[0]["id"]
+        return None
 
     async def search(
         self,

--- a/nemori/db/semantic_store.py
+++ b/nemori/db/semantic_store.py
@@ -27,6 +27,7 @@ class PgSemanticStore:
             ON CONFLICT (id) DO UPDATE SET
                 content = EXCLUDED.content,
                 memory_type = EXCLUDED.memory_type,
+                source_episode_id = EXCLUDED.source_episode_id,
                 confidence = EXCLUDED.confidence,
                 metadata = EXCLUDED.metadata,
                 updated_at = EXCLUDED.updated_at

--- a/nemori/llm/generators/semantic.py
+++ b/nemori/llm/generators/semantic.py
@@ -148,4 +148,4 @@ class SemanticGenerator:
             return "belief"
         if any(w in lower for w in ["every", "always", "usually", "routine", "habit"]):
             return "habit"
-        return "identity"
+        return "unknown"

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -51,6 +51,15 @@ async def test_episode_generator_fallback_on_bad_json(mock_orchestrator, mock_em
     assert episode.user_id == "u1"
 
 
+def test_classify_type_defaults_to_unknown():
+    # A statement matching no keyword bucket must not be silently mislabeled
+    # as "identity"; it should fall through to an explicit "unknown".
+    assert SemanticGenerator._classify_type("The meeting room had blue walls") == "unknown"
+    # Sanity: real buckets still classify.
+    assert SemanticGenerator._classify_type("Her name is Ada") == "identity"
+    assert SemanticGenerator._classify_type("He wants to run a marathon") == "goal"
+
+
 @pytest.mark.asyncio
 async def test_semantic_generator_returns_memories(mock_orchestrator, mock_embedding):
     mock_orchestrator.execute = AsyncMock(return_value=LLMResponse(

--- a/tests/test_memory_system.py
+++ b/tests/test_memory_system.py
@@ -90,3 +90,72 @@ async def test_delete_user(system, deps):
 @pytest.mark.asyncio
 async def test_drain(system):
     await system.drain(timeout=1.0)
+
+
+# --- Semantic dedup / supersession -----------------------------------------
+
+def test_resolve_dedupe_id_above_threshold():
+    hits = [{"id": "existing-1", "score": 0.92}]
+    assert MemorySystem._resolve_dedupe_id(hits, 0.85, set()) == "existing-1"
+
+
+def test_resolve_dedupe_id_below_threshold():
+    hits = [{"id": "existing-1", "score": 0.50}]
+    assert MemorySystem._resolve_dedupe_id(hits, 0.85, set()) is None
+
+
+def test_resolve_dedupe_id_skips_already_used():
+    hits = [{"id": "existing-1", "score": 0.99}]
+    assert MemorySystem._resolve_dedupe_id(hits, 0.85, {"existing-1"}) is None
+
+
+def test_resolve_dedupe_id_empty_hits():
+    assert MemorySystem._resolve_dedupe_id([], 0.85, set()) is None
+
+
+@pytest.mark.asyncio
+async def test_dedupe_semantic_supersedes_near_duplicate(system, deps):
+    deps["qdrant"].search_semantic = MagicMock(
+        return_value=[{"id": "old-fact", "score": 0.95}]
+    )
+    mem = SemanticMemory(
+        user_id="u1", content="User works at Globex",
+        memory_type="identity", embedding=[0.1] * 10,
+    )
+    original_id = mem.id
+    result = await system._dedupe_semantic("u1", [mem])
+    # Near-duplicate reuses the existing id so the store UPDATEs in place.
+    assert result[0].id == "old-fact"
+    assert result[0].id != original_id
+
+
+@pytest.mark.asyncio
+async def test_dedupe_semantic_keeps_distinct_fact(system, deps):
+    deps["qdrant"].search_semantic = MagicMock(
+        return_value=[{"id": "old-fact", "score": 0.40}]
+    )
+    mem = SemanticMemory(
+        user_id="u1", content="A brand new unrelated fact",
+        memory_type="identity", embedding=[0.1] * 10,
+    )
+    original_id = mem.id
+    result = await system._dedupe_semantic("u1", [mem])
+    # Below threshold -> stays a fresh memory.
+    assert result[0].id == original_id
+
+
+@pytest.mark.asyncio
+async def test_dedupe_semantic_disabled_via_config(deps):
+    deps["config"] = MemoryConfig(enable_semantic_dedup=False)
+    deps["buffer_store"].count_unprocessed = AsyncMock(return_value=0)
+    sys_no_dedup = MemorySystem(**deps)
+    deps["qdrant"].search_semantic = MagicMock(
+        return_value=[{"id": "old-fact", "score": 0.99}]
+    )
+    mem = SemanticMemory(
+        user_id="u1", content="x", memory_type="identity", embedding=[0.1] * 10,
+    )
+    original_id = mem.id
+    result = await sys_no_dedup._dedupe_semantic("u1", [mem])
+    assert result[0].id == original_id
+    deps["qdrant"].search_semantic.assert_not_called()

--- a/tests/test_semantic_store.py
+++ b/tests/test_semantic_store.py
@@ -31,6 +31,7 @@ async def test_save_calls_upsert(store, mock_db):
     call_sql = mock_db.execute.call_args[0][0]
     assert "INSERT INTO semantic_memories" in call_sql
     assert "ON CONFLICT" in call_sql
+    assert "source_episode_id = EXCLUDED.source_episode_id" in call_sql
     # Embedding should NOT be in the SQL anymore
     assert "embedding" not in call_sql.lower()
 


### PR DESCRIPTION
## Summary
- Reuse existing semantic memory IDs for near-duplicate extracted facts so updates supersede prior facts instead of appending conflicting duplicates.
- Add a config flag, `enable_semantic_dedup`, defaulting to enabled.
- Refresh `source_episode_id` during semantic-memory upserts so superseded facts point at the new source episode.
- Change semantic type fallback from `identity` to `unknown` to avoid silently misclassifying unmatched statements.

## Why
Without this, semantic extraction can leave stale and updated facts live at the same time. Reusing the matched memory ID lets the existing store upsert path update the prior fact in place.

## Behavior note
This changes recall behavior because semantic facts above the configured similarity threshold are superseded instead of retained as duplicate live facts. The behavior is gated behind `enable_semantic_dedup` and defaults on. Happy to run LoCoMo/LongMemEval before merge if useful.

## Lockfile note
This PR intentionally excludes `uv.lock`. The stale lockfile and Python pin are handled separately in #18. Until #18 lands, plain `uv run` on upstream `main` may refresh `uv.lock` locally; any such local churn was restored and is not part of this PR.

## Tests
- `uv run --python /usr/local/bin/python3.11 --extra dev python -m pytest tests/test_memory_system.py tests/test_generators.py tests/test_semantic_store.py`
- `uv run --python /usr/local/bin/python3.11 --extra dev python -m pytest --ignore tests/test_e2e_full.py --ignore tests/test_integration_openrouter.py`
